### PR TITLE
fix: correct jest-either type exports

### DIFF
--- a/packages/jest-either/package.json
+++ b/packages/jest-either/package.json
@@ -30,9 +30,10 @@
   },
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
-  "types": "lib/index.d.ts",
+  "types": "lib/esm/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/esm/index.d.ts",
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
     }


### PR DESCRIPTION
## Summary
- point `@pacote/jest-either` package `types` metadata at the generated ESM declaration file
- add an `exports["."].types` condition so TypeScript NodeNext consumers can resolve the root package types

## Why
The published `@pacote/jest-either@6.0.1` package declares `types: lib/index.d.ts`, but the npm tarball contains `lib/esm/index.d.ts` and `lib/cjs/index.d.ts` instead. Because the package also defines `exports`, TypeScript NodeNext consumers cannot resolve the root package declarations without an explicit `types` export condition.

## Validation
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm exec biome check package.json packages/jest-either/package.json`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm --filter @pacote/jest-either... build`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm vitest run packages/jest-either/test`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm lint` — exits 0; reports two existing unused-suppression warnings in `packages/error/src/index.ts`
- `npm pack --dry-run --ignore-scripts --json ./packages/jest-either`
- packed `packages/jest-either`, installed it into a temporary NodeNext TypeScript consumer, and verified `import matchers, * as named from "@pacote/jest-either"` compiles with `tsc --noEmit`
- `git diff --check`
